### PR TITLE
fix #43

### DIFF
--- a/src/quickpage/neuprint_connector.py
+++ b/src/quickpage/neuprint_connector.py
@@ -777,7 +777,6 @@ class NeuPrintConnector:
             RETURN upstream.type as partner_type,
                     COALESCE(
                         upstream.somaSide,
-                        apoc.coll.flatten(apoc.text.regexGroups(upstream.instance, '_([LR])$'))[1],
                         ''
                     ) as soma_side,
                    COALESCE(upstream.consensusNt, 'Unknown') as neurotransmitter,
@@ -818,7 +817,6 @@ class NeuPrintConnector:
             RETURN downstream.type as partner_type,
                     COALESCE(
                         downstream.somaSide,
-                        apoc.coll.flatten(apoc.text.regexGroups(downstream.instance, '_([LR])$'))[1],
                         ''
                     ) as soma_side,
                     COALESCE(downstream.consensusNt, 'Unknown') as neurotransmitter,

--- a/src/quickpage/page_generator.py
+++ b/src/quickpage/page_generator.py
@@ -2861,7 +2861,7 @@ class PageGenerator:
         clean_type = neuron_type.replace('/', '_').replace(' ', '_')
 
         # Handle different soma side formats with new naming scheme
-        if soma_side in ['all', 'both']:
+        if soma_side in ['all', 'both', '']:
             # General page for neuron type (multiple sides available)
             filename = f"{clean_type}.html"
         else:


### PR DESCRIPTION
The query was too clever: it extracted the soma side from the instance name if it couldn't find it in the somaSide property. Since we don't do that anywhere except in the connectivity table, I removed that part. 
Also, links to pages without a soma side had the `_` attached to the name.

I tested most examples from #43, didn't see the problem anymore.