### PR TITLE
clarify partner numbers

### DIFF
--- a/templates/help.html.jinja
+++ b/templates/help.html.jinja
@@ -471,7 +471,7 @@
             <ul>
               <li><strong>Upstream Partners:</strong> Neurons that provide input (pre-synaptic partners)</li>
               <li><strong>Downstream Partners:</strong> Neurons that receive output (post-synaptic partners)</li>
-              <li><strong>Number of connected partner:</strong> The number of partner neurons to the target type.</li>
+              <li><strong>Number of connected partner:</strong> The celltype count of the connected partners. Note: This is not the number of neurons of that type that act as upstream or downstream partners.</li>
               <li><strong>Number of connections per neuron:</strong> Number of synaptic connections per target neuron.</li>
               <li><strong>Percentage Contribution:</strong> Percentage of total synaptic connections to/from the target type.</li>
                <li><strong>CV:</strong> Coefficient of variation for the number of connections per neuron.</li>

--- a/templates/sections/connectivity.html.jinja
+++ b/templates/sections/connectivity.html.jinja
@@ -13,7 +13,7 @@
                     <thead>
                         <tr>
                             <th>upstream<br />partner</th>
-                            <th title="number of partner neurons">#</th>
+                            <th title="celltype neuron count for upstream partner">#</th>
                             <th title="neurotransmitter">NT</th>
                             <th title="connections per {{ neuron_data.type -}}">
                                 <span style="text-decoration:underline #333 2px; text-underline-offset: 0.4em;">conns</span><br /> {{- neuron_data.type -}}
@@ -62,7 +62,7 @@
                     <thead>
                         <tr>
                             <th>downstream<br/>partner</th>
-                            <th title="number of partner neurons">#</th>
+                            <th title="celltype neuron count for downstream partner">#</th>
                             <th title="neurotransmitter">NT</th>
                             <th title="connections per {{- neuron_data.type -}}">
                                 <span style="text-decoration:underline #333 2px; text-underline-offset: 0.4em;">conns</span><br /> {{- neuron_data.type -}}


### PR DESCRIPTION
Minor tweak to the tooltip and help page to clarify what the # column in the connectivity table means.