### PR TITLE
improve version handling

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -123,6 +123,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.12-h718f522_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -275,6 +276,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.12-h3caf6b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -422,6 +424,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.12.12-h2342e2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -571,6 +574,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.12.12-h429b229_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -745,6 +749,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.12-h718f522_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -905,6 +910,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.12-h3caf6b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -1060,6 +1066,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.12.12-h2342e2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -1217,6 +1224,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rope-1.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.12.12-h429b229_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -4010,7 +4018,7 @@ packages:
 - pypi: ./
   name: neuview
   version: 0.1.0
-  sha256: bb9e6dc6e8d6ec267bfc63797e088ae0c9768eea15d6d42efba26f1d0bc8311a
+  sha256: 97b7e4bebe4885147f1a9aa8f0e3fbdd39a03172425dbefa01c9b9a22e3bf7df
   requires_dist:
   - click>=8.0.0
   - jinja2>=3.0.0
@@ -5742,6 +5750,17 @@ packages:
   - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
+  sha256: 7d3f5531269e15cb533b60009aa2a950f9844acf31f38c1b55c8000dbb316676
+  md5: 982aa48accc06494cbd2b51af69e17c7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/semver?source=hash-mapping
+  size: 21110
+  timestamp: 1737841666447
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ python-lsp-server = ">=1.13.1,<2"
 ruff = ">=0.12.11,<0.13"
 pyprojroot = ">=0.3.0,<0.4"
 psutil = ">=7.1.0,<8"
+semver = ">=3.0.4,<4"
 
 [tool.pixi.feature.dev.dependencies]
 pytest = "*"

--- a/scripts/increment_version.py
+++ b/scripts/increment_version.py
@@ -1,136 +1,246 @@
 #!/usr/bin/env python3
 """
-Auto-increment version script for quickpage project.
+Auto-increment version script for neuview project.
 
-This script runs after the 'create-all-pages' pixi task succeeds.
-It reads the current version from git tags, increments the patch version,
-and creates a new git tag.
+This script implements a new workflow for version management:
+1. Reads the current version from git tags (source of truth)
+2. Increments the patch version by 1
+3. Updates the version in pyproject.toml (without 'v' prefix)
+4. Commits that change to the current branch
+5. Creates a git tag with the v-prefixed version
+
+The script uses GitPython exclusively for all git operations (no CLI commands), the
+semver package for version parsing and incrementing, and the toml package for
+pyproject.toml manipulation.
+
+Example workflow:
+  Current git tag: v2.7.4
+  → Update pyproject.toml version to "2.7.5"
+  → Commit: "Bump version to v2.7.5"
+  → Create git tag: v2.7.5
 """
 
-import subprocess
 import sys
-import re
 import argparse
-from typing import Optional, Tuple
+import toml
+import semver
+from pathlib import Path
+from typing import Optional
+from git import Repo, InvalidGitRepositoryError, GitCommandError
 
 
-def run_command(cmd: list[str]) -> Tuple[int, str, str]:
-    """Run a command and return exit code, stdout, stderr."""
+def get_git_repo() -> Repo:
+    """Get the git repository object."""
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        return result.returncode, result.stdout.strip(), result.stderr.strip()
-    except Exception as e:
-        return 1, "", str(e)
+        # Find the git repository (searches upwards from current directory)
+        repo = Repo(search_parent_directories=True)
+        return repo
+    except InvalidGitRepositoryError:
+        print("Error: Not in a git repository", file=sys.stderr)
+        sys.exit(1)
 
 
 def get_latest_version() -> Optional[str]:
-    """Get the latest version tag from git."""
-    # Get all tags and sort them by version
-    exit_code, stdout, stderr = run_command(
-        ["git", "tag", "--list", "--sort=-version:refname"]
-    )
+    """Get the latest version tag from git using GitPython."""
+    try:
+        repo = get_git_repo()
 
-    if exit_code != 0:
-        print(f"Error getting git tags: {stderr}", file=sys.stderr)
+        # Get all tags
+        tags = list(repo.tags)
+
+        if not tags:
+            print("No git tags found", file=sys.stderr)
+            return None
+
+        # Sort tags by the commit date they reference (most recent last)
+        try:
+            sorted_tags = sorted(
+                tags, key=lambda t: t.commit.committed_datetime, reverse=True
+            )
+        except Exception as e:
+            print(f"Error sorting tags by commit date: {e}", file=sys.stderr)
+            # Fallback: sort tags alphabetically by name
+            sorted_tags = sorted(tags, key=str, reverse=True)
+
+        # Find the first tag that matches semantic versioning pattern
+        for tag in sorted_tags:
+            tag_name = str(tag)
+            try:
+                # Try to parse as semver to validate format
+                version_str = tag_name.lstrip("v")
+                version_parts = version_str.split(".")
+                if len(version_parts) == 2:
+                    version_str = f"{version_str}.0"
+                elif len(version_parts) == 1:
+                    version_str = f"{version_str}.0.0"
+
+                semver.Version.parse(version_str)
+                return tag_name
+            except ValueError:
+                continue
+
+        print("No valid semantic version tags found", file=sys.stderr)
         return None
 
-    if not stdout:
-        print("No git tags found", file=sys.stderr)
+    except GitCommandError as e:
+        print(f"Git command error: {e}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error getting git tags: {e}", file=sys.stderr)
         return None
 
-    tags = stdout.split("\n")
 
-    # Find the first tag that matches semantic versioning pattern
-    semver_pattern = re.compile(r"^v?(\d+)\.(\d+)(?:\.(\d+))?$")
-
-    for tag in tags:
-        if semver_pattern.match(tag):
-            return tag
-
-    print("No valid semantic version tags found", file=sys.stderr)
-    return None
-
-
-def parse_version(version_tag: str) -> Tuple[int, int, int]:
-    """Parse a version tag into major, minor, patch components."""
+def parse_version(version_tag: str) -> semver.Version:
+    """Parse a version tag into a semver Version object."""
     # Remove 'v' prefix if present
-    version = version_tag.lstrip("v")
+    version_str = version_tag.lstrip("v")
 
-    semver_pattern = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?$")
-    match = semver_pattern.match(version)
+    # Handle incomplete versions by normalizing them first
+    # Convert "1.2" to "1.2.0" for proper semver parsing
+    version_parts = version_str.split(".")
+    if len(version_parts) == 2:
+        version_str = f"{version_str}.0"
+    elif len(version_parts) == 1:
+        version_str = f"{version_str}.0.0"
 
-    if not match:
-        raise ValueError(f"Invalid version format: {version_tag}")
-
-    major = int(match.group(1))
-    minor = int(match.group(2))
-    patch = int(match.group(3)) if match.group(3) else 0
-
-    return major, minor, patch
+    try:
+        return semver.Version.parse(version_str)
+    except ValueError as e:
+        raise ValueError(f"Invalid version format: {version_tag}") from e
 
 
-def increment_patch_version(major: int, minor: int, patch: int) -> str:
-    """Increment the patch version."""
-    return f"v{major}.{minor}.{patch + 1}"
+def get_project_root() -> Path:
+    """Get the project root directory (where pyproject.toml is located)."""
+    try:
+        repo = get_git_repo()
+        project_root = Path(repo.working_dir)
+        pyproject_path = project_root / "pyproject.toml"
+
+        if not pyproject_path.exists():
+            raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
+
+        return project_root
+    except Exception as e:
+        print(f"Error finding project root: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def update_pyproject_version(new_version_without_v: str, dry_run: bool = False) -> bool:
+    """Update the version in pyproject.toml using toml package."""
+    try:
+        project_root = get_project_root()
+        pyproject_path = project_root / "pyproject.toml"
+
+        # Read the current pyproject.toml
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            pyproject_data = toml.load(f)
+
+        # Get current version for comparison
+        current_version = pyproject_data.get("project", {}).get("version", "unknown")
+        print(f"Current pyproject.toml version: {current_version}")
+        print(f"New pyproject.toml version: {new_version_without_v}")
+
+        if dry_run:
+            print(
+                f"[DRY RUN] Would update pyproject.toml version to: {new_version_without_v}"
+            )
+            return True
+
+        # Update the version
+        if "project" not in pyproject_data:
+            pyproject_data["project"] = {}
+        pyproject_data["project"]["version"] = new_version_without_v
+
+        # Write back to file
+        with open(pyproject_path, "w", encoding="utf-8") as f:
+            toml.dump(pyproject_data, f)
+
+        print(
+            f"Successfully updated pyproject.toml version to: {new_version_without_v}"
+        )
+        return True
+
+    except Exception as e:
+        print(f"Error updating pyproject.toml: {e}", file=sys.stderr)
+        return False
+
+
+def commit_version_change(new_version_with_v: str, dry_run: bool = False) -> bool:
+    """Commit the version change to git using GitPython."""
+    try:
+        repo = get_git_repo()
+
+        # Add pyproject.toml to staging
+        try:
+            repo.index.add(["pyproject.toml"])
+        except Exception as e:
+            print(f"Error adding pyproject.toml to git: {e}", file=sys.stderr)
+            return False
+
+        # Check if there are changes to commit
+        if not repo.index.diff("HEAD"):
+            print("No changes to commit in pyproject.toml")
+            return True
+
+        if dry_run:
+            print(
+                f"[DRY RUN] Would commit version change with message: 'Bump version to {new_version_with_v}'"
+            )
+            return True
+
+        # Commit the changes
+        commit_message = f"Bump version to {new_version_with_v}"
+        try:
+            repo.index.commit(commit_message)
+            print(f"Successfully committed version change: {commit_message}")
+            return True
+        except Exception as e:
+            print(f"Error committing version change: {e}", file=sys.stderr)
+            return False
+
+    except Exception as e:
+        print(f"Error in git commit operation: {e}", file=sys.stderr)
+        return False
 
 
 def create_git_tag(tag: str, dry_run: bool = False) -> bool:
-    """Create a new git tag."""
-    # First check if the tag already exists
-    exit_code, stdout, stderr = run_command(["git", "tag", "--list", tag])
-    if exit_code != 0:
-        print(f"Error checking existing tags: {stderr}", file=sys.stderr)
+    """Create a new git tag using GitPython."""
+    try:
+        repo = get_git_repo()
+
+        # Check if the tag already exists
+        existing_tags = [str(t) for t in repo.tags]
+        if tag in existing_tags:
+            print(f"Tag {tag} already exists, skipping creation", file=sys.stderr)
+            return False
+
+        if dry_run:
+            print(f"[DRY RUN] Would create git tag: {tag}")
+            return True
+
+        # Create the tag
+        try:
+            repo.create_tag(tag, message=f"Release {tag}")
+            print(f"Successfully created git tag: {tag}")
+            return True
+        except Exception as e:
+            print(f"Error creating git tag: {e}", file=sys.stderr)
+            return False
+
+    except Exception as e:
+        print(f"Error in git tag operation: {e}", file=sys.stderr)
         return False
-
-    if stdout:
-        print(f"Tag {tag} already exists, skipping creation", file=sys.stderr)
-        return False
-
-    # Check if we have any uncommitted changes
-    exit_code, stdout, stderr = run_command(["git", "status", "--porcelain"])
-    if exit_code != 0:
-        print(f"Error checking git status: {stderr}", file=sys.stderr)
-        return False
-
-    if stdout:
-        print(
-            "Warning: There are uncommitted changes in the repository", file=sys.stderr
-        )
-        print("Staged/modified files:", file=sys.stderr)
-        print(stdout, file=sys.stderr)
-        # Continue anyway as the user might want to tag the current state
-
-    # Create the tag
-    if dry_run:
-        print(f"[DRY RUN] Would create git tag: {tag}")
-        return True
-
-    exit_code, stdout, stderr = run_command(
-        [
-            "git",
-            "tag",
-            "-a",
-            tag,
-            "-m",
-            f"Auto-increment patch to {tag} after successful create-all-pages",
-        ]
-    )
-
-    if exit_code != 0:
-        print(f"Error creating git tag: {stderr}", file=sys.stderr)
-        return False
-
-    print(f"Successfully created git tag: {tag}")
-    return True
 
 
 def main():
-    """Main function to increment version and create tag."""
-    parser = argparse.ArgumentParser(description="Increment version and create git tag")
+    """Main function to increment version, update pyproject.toml, commit, and create tag."""
+    parser = argparse.ArgumentParser(
+        description="Increment version, update pyproject.toml, commit, and create git tag"
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Show what would be done without actually creating the tag",
+        help="Show what would be done without making actual changes",
     )
 
     args = parser.parse_args()
@@ -146,34 +256,56 @@ def main():
         print("Could not determine latest version", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Current latest version: {latest_version}")
+    print(f"Current latest git tag: {latest_version}")
 
     try:
         # Parse the version
-        major, minor, patch = parse_version(latest_version)
-        print(f"Parsed version: major={major}, minor={minor}, patch={patch}")
+        parsed_version = parse_version(latest_version)
+        print(
+            f"Parsed version: major={parsed_version.major}, minor={parsed_version.minor}, patch={parsed_version.patch}"
+        )
 
         # Increment patch version
-        new_version = increment_patch_version(major, minor, patch)
-        print(f"New version: {new_version}")
+        incremented_version = parsed_version.bump_patch()
+        new_version_with_v = f"v{incremented_version}"
+        new_version_without_v = str(incremented_version)
 
-        # Create the git tag
-        if create_git_tag(new_version, dry_run=args.dry_run):
-            if args.dry_run:
-                print(
-                    f"[DRY RUN] Would increment version from {latest_version} to {new_version}"
-                )
-                print(f"[DRY RUN] To actually create the tag, run without --dry-run")
-            else:
-                print(
-                    f"Version successfully incremented from {latest_version} to {new_version}"
-                )
+        print(f"New version (for git tag): {new_version_with_v}")
+        print(f"New version (for pyproject.toml): {new_version_without_v}")
 
-            # Optionally push the tag (commented out by default for safety)
-            # print("To push the tag to remote, run: git push origin", new_version)
-        else:
+        # Step 1: Update pyproject.toml
+        if not update_pyproject_version(new_version_without_v, dry_run=args.dry_run):
+            print("Failed to update pyproject.toml", file=sys.stderr)
+            sys.exit(1)
+
+        # Step 2: Commit the change
+        if not commit_version_change(new_version_with_v, dry_run=args.dry_run):
+            print("Failed to commit version change", file=sys.stderr)
+            sys.exit(1)
+
+        # Step 3: Create the git tag
+        if not create_git_tag(new_version_with_v, dry_run=args.dry_run):
             print("Failed to create git tag", file=sys.stderr)
             sys.exit(1)
+
+        if args.dry_run:
+            print(f"\n[DRY RUN] Summary of what would be done:")
+            print(f"  1. Update pyproject.toml version: {new_version_without_v}")
+            print(
+                f"  2. Commit change with message: 'Bump version to {new_version_with_v}'"
+            )
+            print(f"  3. Create git tag: {new_version_with_v}")
+            print(f"\nTo actually perform these actions, run without --dry-run")
+        else:
+            print(
+                f"\n✓ Successfully incremented version from {latest_version} to {new_version_with_v}"
+            )
+            print(f"  • Updated pyproject.toml to version {new_version_without_v}")
+            print(f"  • Committed the change")
+            print(f"  • Created git tag {new_version_with_v}")
+            print(f"\nNext steps (optional):")
+            print(f"  • Push commits: git push")
+            print(f"  • Push tag: git push origin {new_version_with_v}")
 
     except ValueError as e:
         print(f"Error parsing version: {e}", file=sys.stderr)

--- a/src/neuview/utils/version_utils.py
+++ b/src/neuview/utils/version_utils.py
@@ -3,31 +3,83 @@ Version utilities for retrieving git version information.
 
 This module provides utilities for getting version information from git,
 with appropriate error handling and fallbacks.
+
+Note: The get_git_version() function automatically increments the patch version
+by 1 from the latest git tag using semantic versioning. This provides a
+"next version" display for development builds.
+
+Version parsing requires the python-semver package.
 """
 
 import logging
 from pathlib import Path
 from typing import Optional
 from git import Repo, InvalidGitRepositoryError, GitCommandError
+import semver
 
 logger = logging.getLogger(__name__)
 
 
-def get_git_version(repo_path: Optional[str] = None) -> str:
-    """Get the latest git tag version.
+def _increment_patch_version(version_tag: str) -> str:
+    """Increment the patch version of a semver tag by 1.
 
-    This function attempts to retrieve the latest git tag using GitPython.
-    It finds the most recent tag by commit date.
+    Uses python-semver package to parse and increment versions. Handles incomplete
+    versions like "v1.2" by normalizing to "v1.2.0" before incrementing.
+
+    Args:
+        version_tag: Version tag string (e.g., "v1.2.3" or "1.2.3")
+
+    Returns:
+        New version tag with patch incremented by 1 (e.g., "v1.2.4")
+    """
+    try:
+        # Preserve the 'v' prefix if it was present in the original
+        has_v_prefix = version_tag.startswith("v")
+        clean_version = version_tag.lstrip("v")
+
+        # Handle incomplete versions by normalizing them first
+        # Convert "1.2" to "1.2.0" for proper semver parsing
+        version_parts = clean_version.split(".")
+        if len(version_parts) == 2:
+            clean_version = f"{clean_version}.0"
+        elif len(version_parts) == 1:
+            clean_version = f"{clean_version}.0.0"
+
+        # Parse and validate the version using python-semver
+        parsed_version = semver.Version.parse(clean_version)
+
+        # Increment the patch version
+        incremented_version = parsed_version.bump_patch()
+
+        # Return with original prefix
+        prefix = "v" if has_v_prefix else ""
+        return f"{prefix}{incremented_version}"
+
+    except (ValueError, semver.VersionError) as e:
+        # If we can't parse it as semver, return the original
+        logger.debug(f"Could not parse version as semver: {version_tag}, error: {e}")
+        return version_tag
+
+
+def get_git_version(repo_path: Optional[str] = None) -> str:
+    """Get the latest git tag version with patch incremented by 1.
+
+    This function attempts to retrieve the latest git tag using GitPython,
+    finds the most recent tag by commit date, and automatically increments
+    the patch version by 1 using semantic versioning.
 
     Args:
         repo_path: Path to git repository. If None, uses current directory.
 
     Returns:
-        Git tag version string, or 'unknown' if not available
+        Git tag version string with patch incremented by 1, or 'unknown' if not available
 
     Examples:
-        >>> version = get_git_version()
-        >>> print(version)  # e.g., "v2.6" or "unknown"
+        >>> version = get_git_version()  # Latest tag is "v2.7.4"
+        >>> print(version)  # Outputs "v2.7.5"
+
+        >>> version = get_git_version()  # Latest tag is "v1.5.0"
+        >>> print(version)  # Outputs "v1.5.1"
     """
     try:
         # Use current directory if no path specified
@@ -49,18 +101,24 @@ def get_git_version(repo_path: Optional[str] = None) -> str:
             sorted_tags = sorted(tags, key=lambda t: t.commit.committed_datetime)
             latest_tag = sorted_tags[-1]
 
-            # Return the tag name (remove 'refs/tags/' prefix if present)
+            # Return the tag name with patch incremented by 1
             tag_name = str(latest_tag)
-            logger.debug(f"Found latest git tag: {tag_name}")
-            return tag_name
+            incremented_version = _increment_patch_version(tag_name)
+            logger.debug(
+                f"Found latest git tag: {tag_name}, incremented to: {incremented_version}"
+            )
+            return incremented_version
 
         except Exception as e:
             logger.debug(f"Error sorting tags by commit date: {e}")
             # Fallback: just use the last tag alphabetically
             latest_tag = sorted(tags, key=str)[-1]
             tag_name = str(latest_tag)
-            logger.debug(f"Using alphabetically last tag as fallback: {tag_name}")
-            return tag_name
+            incremented_version = _increment_patch_version(tag_name)
+            logger.debug(
+                f"Using alphabetically last tag as fallback: {tag_name}, incremented to: {incremented_version}"
+            )
+            return incremented_version
 
     except InvalidGitRepositoryError:
         logger.debug("Not in a git repository")
@@ -116,7 +174,7 @@ def get_version_info(repo_path: Optional[str] = None) -> dict:
 
     Returns:
         Dictionary containing version information including:
-        - git_version: Git tag version
+        - git_version: Git tag version with patch incremented by 1
         - git_available: Whether git is available
         - git_describe: Git describe output
         - package_version: Package version from __init__.py if available


### PR DESCRIPTION
Instead of using the current git version, the page generator always increases the path part of the semantic versioning. At the end of a create-all-pages run, it will also increase the git version, add it to pyproject.toml and add a git tag. This should decrease the number of incidental errors with neuView versioning…