### PR TITLE
show up to date metadata information on index and README

### DIFF
--- a/src/neuview/services/index_service.py
+++ b/src/neuview/services/index_service.py
@@ -237,7 +237,7 @@ class IndexService:
                 if filename_based_name not in filename_to_neuron_map:
                     names_needing_db_lookup.append(filename_based_name)
 
-        # Only initialize connector if we need database lookups
+        # Only initialize connector if we need database lookups or metadata retrieval
         connector = None
         if names_needing_db_lookup or not roi_hierarchy_loaded:
             try:
@@ -260,6 +260,21 @@ class IndexService:
 
             except Exception as e:
                 logger.warning(f"Failed to initialize connector: {e}")
+        else:
+            # Even if we don't need database lookups for names or ROI hierarchy,
+            # we still need the connector for metadata retrieval (UUID, etc.)
+            try:
+                init_start = time.time()
+                from ..neuprint_connector import NeuPrintConnector
+
+                connector = NeuPrintConnector(self.config)
+                init_time = time.time() - init_start
+                logger.info(
+                    f"Database connector initialized for metadata retrieval in {init_time:.3f}s"
+                )
+
+            except Exception as e:
+                logger.warning(f"Failed to initialize connector for metadata: {e}")
 
         return connector
 

--- a/templates/README_template.md.jinja
+++ b/templates/README_template.md.jinja
@@ -2,6 +2,8 @@
 
 **Dataset:** {{ config.neuprint.dataset }}
 **Server:** {{ config.neuprint.server }}
+**Dataset UUID:** {{ metadata.uuid }}
+**Dataset Last Updated:** {{ metadata.lastDatabaseEdit }}
 **Generated:** {{ generation_time.strftime('%Y-%m-%d %H:%M:%S UTC') }}
 **Total Neuron Types:** {{ total_types }}
 
@@ -174,6 +176,8 @@ Neurotransmitter assignments are computational predictions based on:
 
 **Source Database**: neuPrint ({{ config.neuprint.server }})
 **Dataset Version**: {{ config.neuprint.dataset }}
+**Dataset UUID**: {{ metadata.uuid }}
+**Dataset Last Updated**: {{ metadata.lastDatabaseEdit }}
 **Data Type**: Electron microscopy connectome data
 **Species**: *Drosophila melanogaster*
 **Resolution**: Synaptic-level connectivity
@@ -194,8 +198,9 @@ Neurotransmitter assignments are computational predictions based on:
 
 When using data from this catalog, please cite:
 1. The original neuPrint database and dataset
-2. The specific dataset version ({{ config.neuprint.dataset }})
-3. The generation date of this catalog ({{ generation_time.strftime('%Y-%m-%d') }})
+2. The specific dataset version ({{ config.neuprint.dataset }}) with UUID {{ metadata.uuid }}
+3. The dataset last updated on {{ metadata.lastDatabaseEdit }}
+4. The generation date of this catalog ({{ generation_time.strftime('%Y-%m-%d') }})
 
 For the most current citation information, visit the neuPrint database at {{ config.neuprint.server }}.
 
@@ -216,4 +221,4 @@ For questions about the data or analysis methods, consult the neuPrint database 
 
 ---
 
-*This catalog was automatically generated from neuPrint data on {{ generation_time.strftime('%Y-%m-%d at %H:%M:%S UTC') }}. For the most up-to-date information, please consult the original neuPrint database.*
+*This catalog was automatically generated from neuPrint data on {{ generation_time.strftime('%Y-%m-%d at %H:%M:%S UTC') }} using dataset {{ config.neuprint.dataset }} (UUID: {{ metadata.uuid }}, last updated: {{ metadata.lastDatabaseEdit }}). For the most up-to-date information, please consult the original neuPrint database.*

--- a/templates/help.html.jinja
+++ b/templates/help.html.jinja
@@ -60,7 +60,7 @@
           <h2>Overview</h2>
           <p>
             This neuron type catalog provides comprehensive information about neurons in the
-            <strong>{{ config.neuprint.dataset | upper }}</strong> dataset. The catalog includes detailed morphological,
+            <strong>{{ config.neuprint.dataset }}</strong> dataset. The catalog includes detailed morphological,
             connectivity, and functional data for each neuron type, organized into an easy-to-navigate interface.
           </p>
           <blockquote>
@@ -386,11 +386,11 @@
               Counts are aggregated from annotated synapse locations using standardized layer definitions for each
               neuropil.<sub>1</sub></li>
               <li><strong>Input vs. output balance per layer:</strong> Represented by the yellow (input) and blue (output) bars.</li>
-              <li>Please note that these tables display synapse counts only for the <strong>ipsilateral</strong> 
-              optic lobe regions — that is, the lobe on the same side as the soma. For example, the “Tm3_R” page shows 
-              synapses of Tm3_R neurons within the right optic lobe. Consequently, neuron types that project 
-              exclusively to the <strong>contralateral</strong> optic lobe (e.g., DNc02) do not have layer tables. 
-              For <strong>bilateral</strong> neuron types (e.g., MeVPMe13), which innervate both optic lobes, 
+              <li>Please note that these tables display synapse counts only for the <strong>ipsilateral</strong>
+              optic lobe regions — that is, the lobe on the same side as the soma. For example, the “Tm3_R” page shows
+              synapses of Tm3_R neurons within the right optic lobe. Consequently, neuron types that project
+              exclusively to the <strong>contralateral</strong> optic lobe (e.g., DNc02) do not have layer tables.
+              For <strong>bilateral</strong> neuron types (e.g., MeVPMe13), which innervate both optic lobes,
               the tables include only the counts for the ipsilateral synapses.</li>
             </ul>
 

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -13,7 +13,7 @@
             <div class="landing-page">
                 <div class="hero-section">
                     <h1>{{ config.html.title_prefix }} – Cell Type Explorer</h1>
-                    <p class="lead">Comprehensive neuron type catalog for the {{ config.neuprint.dataset | upper }} dataset</p>
+                    <p class="lead">Comprehensive neuron type catalog for the {{ config.neuprint.dataset}} dataset</p>
 
                     <div class="stats-overview">
                         <div class="stat-item">
@@ -54,13 +54,13 @@
                     <h2>About This Dataset</h2>
                     <p>
                         This Cell Type Catalog presents a comprehensive view of neuron types from the
-                        <strong>{{ config.neuprint.dataset | upper }}</strong> connectome dataset.
+                        <strong>{{ config.neuprint.dataset }}</strong> connectome dataset.
                         For each neuron type in the dataset, we show morphological information, connectivity patterns,
                         and spatial distributions.
                     </p>
                     <p>
                         Data represents a temporal snapshot generated on {{ generation_time.strftime('%Y-%m-%d %H:%M') }} from <a href="https://{{- config.neuprint.server -}}/?dataset={{- config.neuprint.dataset -}}" target="_blank">neuPrint</a>.</p>
-                    <p class="pm-text-light"> At the time, the {{ config.neuprint.dataset | upper }} dataset at {{ config.neuprint.server }} was at version {{ metadata.uuid }} and had the last update at {{ metadata.lastDatabaseEdit }}.
+                    <p class="pm-text-light"> At the time, the {{ config.neuprint.dataset }} dataset at {{ config.neuprint.server }} was at version {{ metadata.uuid }} and had the last update at {{ metadata.lastDatabaseEdit }}.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Previously, the Index page would show "Unknown" database version:

<img width="1492" height="137" alt="image" src="https://github.com/user-attachments/assets/a4db4ac1-a3b5-4596-8e61-f0759c206242" />

This should be fixed now. Also, the same metadata information is added to the README