### PR TITLE
aggregate cellClass/cellSubclass/cellSuperclass/somaNeuromere/trumanHl as lists

### DIFF
--- a/src/neuview/cache.py
+++ b/src/neuview/cache.py
@@ -34,9 +34,13 @@ class NeuronTypeCacheData:
     celltype_predicted_nt: Optional[str] = None
     celltype_predicted_nt_confidence: Optional[float] = None
     celltype_total_nt_predictions: Optional[int] = None
-    cell_class: Optional[str] = None
-    cell_subclass: Optional[str] = None
-    cell_superclass: Optional[str] = None
+    # cell_class / cell_subclass / cell_superclass / soma_neuromere / truman_hl
+    # are stored as sorted lists of distinct non-null values found across the
+    # cells of the celltype, since the male-cns probe showed they are not
+    # celltype-invariant. See neuprint_connector._calculate_summary.
+    cell_class: Optional[List[str]] = None
+    cell_subclass: Optional[List[str]] = None
+    cell_superclass: Optional[List[str]] = None
     dimorphism: Optional[str] = None
     nt_analysis: Optional[List[Dict[str, Any]]] = None
     # Column data for optic lobe neurons
@@ -46,8 +50,8 @@ class NeuronTypeCacheData:
     original_neuron_name: Optional[str] = None
     synonyms: Optional[str] = None
     flywire_types: Optional[str] = None
-    soma_neuromere: Optional[str] = None
-    truman_hl: Optional[str] = None
+    soma_neuromere: Optional[List[str]] = None
+    truman_hl: Optional[List[str]] = None
     spatial_metrics: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None
     # Side-specific synapse counts
     side_synapse_stats: Optional[Dict[str, Dict[str, int]]] = None

--- a/src/neuview/neuprint_connector.py
+++ b/src/neuview/neuprint_connector.py
@@ -20,7 +20,7 @@ from neuprint import Client, NeuronCriteria, fetch_neurons
 from .cache import NeuronTypeCacheManager
 from .config import Config, DiscoveryConfig
 from .dataset_adapters import get_dataset_adapter
-from .utils import extract_first_non_null, extract_unique_joined
+from .utils import extract_first_non_null, extract_unique_joined, extract_unique_list
 
 # Set up logger for performance monitoring
 logger = logging.getLogger(__name__)
@@ -754,7 +754,7 @@ class NeuPrintConnector:
         truman_hl = None
 
         if total_count > 0:
-            # Celltype-level attributes: any non-null row carries the canonical
+            # Celltype-invariant attributes: any non-null row carries the canonical
             # value. extract_first_non_null skips a NaN row 0 when a left-join
             # leaves the joined column empty for that row.
             consensus_nt = extract_first_non_null(
@@ -772,34 +772,31 @@ class NeuPrintConnector:
                 ("celltypeTotalNtPredictions_y", "celltypeTotalNtPredictions"),
             )
 
-            cell_class = extract_first_non_null(
-                neurons_df, ("cellClass_y", "cellClass")
-            )
-            cell_subclass = extract_first_non_null(
-                neurons_df, ("cellSubclass_y", "cellSubclass")
-            )
-            cell_superclass = extract_first_non_null(
-                neurons_df, ("cellSuperclass_y", "cellSuperclass")
-            )
-
             dimorphism = extract_first_non_null(
                 neurons_df, ("dimorphism_y", "dimorphism")
             )
-            synonyms = extract_first_non_null(
-                neurons_df, ("synonyms_y", "synonyms")
-            )
+            synonyms = extract_first_non_null(neurons_df, ("synonyms_y", "synonyms"))
 
-            # FlyWire IDs are per-cell and may legitimately differ across rows,
-            # so aggregate them rather than picking one.
-            flywire_types = extract_unique_joined(
-                neurons_df, ("flywireType_y", "flywireType")
+            # Per-cell attributes that legitimately vary within a celltype.
+            # An empirical check of male-cns:v0.9 showed cellClass / cellSubclass /
+            # cellSuperclass / somaNeuromere / trumanHl all carry distinct values
+            # across cells of many celltypes, so we aggregate rather than pick
+            # one row's value (which is non-deterministic under join ordering).
+            cell_class = extract_unique_list(neurons_df, ("cellClass_y", "cellClass"))
+            cell_subclass = extract_unique_list(
+                neurons_df, ("cellSubclass_y", "cellSubclass")
             )
-
-            soma_neuromere = extract_first_non_null(
+            cell_superclass = extract_unique_list(
+                neurons_df, ("cellSuperclass_y", "cellSuperclass")
+            )
+            soma_neuromere = extract_unique_list(
                 neurons_df, ("somaNeuromere_y", "somaNeuromere")
             )
-            truman_hl = extract_first_non_null(
-                neurons_df, ("trumanHl_y", "trumanHl")
+            truman_hl = extract_unique_list(neurons_df, ("trumanHl_y", "trumanHl"))
+
+            # FlyWire IDs are per-cell and aggregated as a display string.
+            flywire_types = extract_unique_joined(
+                neurons_df, ("flywireType_y", "flywireType")
             )
 
         # Calculate neurotransmitter analysis

--- a/src/neuview/services/roi_analysis_service.py
+++ b/src/neuview/services/roi_analysis_service.py
@@ -167,25 +167,23 @@ class ROIAnalysisService:
             ):
                 nt_options.add(entry["celltype_predicted_nt"].strip())
 
-            # Collect class hierarchy
-            if entry.get("cell_superclass") and entry["cell_superclass"].strip():
-                superclass_options.add(entry["cell_superclass"].strip())
-            if entry.get("cell_class") and entry["cell_class"].strip():
-                class_options.add(entry["cell_class"].strip())
-            if entry.get("cell_subclass") and entry["cell_subclass"].strip():
-                subclass_options.add(entry["cell_subclass"].strip())
+            # Class hierarchy + soma neuromere + truman hl are lists since
+            # cells in the same celltype may carry different values.
+            list_field_targets = (
+                ("cell_superclass", superclass_options),
+                ("cell_class", class_options),
+                ("cell_subclass", subclass_options),
+                ("soma_neuromere", soma_neuromere_options),
+                ("truman_hl", truman_hl_options),
+            )
+            for key, target in list_field_targets:
+                for value in entry.get(key) or []:
+                    if value and value.strip():
+                        target.add(value.strip())
 
             # Collect dimorphism
             if entry.get("dimorphism") and entry["dimorphism"].strip():
                 dimorphism_options.add(entry["dimorphism"].strip())
-
-            # Collect soma neuromere
-            if entry.get("soma_neuromere") and entry["soma_neuromere"].strip():
-                soma_neuromere_options.add(entry["soma_neuromere"].strip())
-
-            # Collect truman hl
-            if entry.get("truman_hl") and entry["truman_hl"].strip():
-                truman_hl_options.add(entry["truman_hl"].strip())
 
         # Sort filter options
         sorted_roi_options = sorted(roi_options)

--- a/src/neuview/services/template_context_service.py
+++ b/src/neuview/services/template_context_service.py
@@ -170,9 +170,7 @@ class TemplateContextService:
         # Synonyms are a celltype-level attribute, so any non-null row
         # carries the canonical value. FlyWire IDs are per-cell and may
         # legitimately differ across rows, so we aggregate them.
-        synonyms_raw = extract_first_non_null(
-            neurons_df, ("synonyms_y", "synonyms")
-        )
+        synonyms_raw = extract_first_non_null(neurons_df, ("synonyms_y", "synonyms"))
         if synonyms_raw is not None:
             processed_synonyms = self.text_utils.process_synonyms(
                 str(synonyms_raw),

--- a/src/neuview/utils/__init__.py
+++ b/src/neuview/utils/__init__.py
@@ -5,7 +5,7 @@ This package contains utility functions and formatters that were extracted
 from the main PageGenerator class to improve code organization and reusability.
 """
 
-from .df_utils import extract_first_non_null, extract_unique_joined
+from .df_utils import extract_first_non_null, extract_unique_joined, extract_unique_list
 from .formatters import (
     NumberFormatter,
     PercentageFormatter,
@@ -35,6 +35,7 @@ __all__ = [
     "TextUtils",
     "extract_first_non_null",
     "extract_unique_joined",
+    "extract_unique_list",
     "get_git_version",
     "get_git_describe",
     "get_version_info",

--- a/src/neuview/utils/df_utils.py
+++ b/src/neuview/utils/df_utils.py
@@ -24,22 +24,36 @@ def extract_first_non_null(
     return None
 
 
-def extract_unique_joined(
-    df: pd.DataFrame, column_names: Iterable[str], sep: str = ", "
-) -> Optional[str]:
-    """Return a sorted, deduped, joined string of all non-NaN values from the first matching column.
+def extract_unique_list(
+    df: pd.DataFrame, column_names: Iterable[str]
+) -> Optional[list]:
+    """Return a sorted list of all unique non-NaN values from the first matching column.
 
     Iterates ``column_names`` in order, picks the first column present in ``df``,
-    and joins the unique non-NaN values with ``sep``. Returns ``None`` if no
+    and returns a sorted list of unique non-NaN values. Returns ``None`` if no
     listed column is present or every value is NaN.
 
-    Use this for per-cell attributes that may legitimately differ across rows
-    and should be aggregated (e.g. ``flywireType``).
+    Use this for celltype-summary fields whose values may legitimately differ
+    across cells in the type (e.g. ``somaNeuromere``, ``cellSubclass``,
+    ``trumanHl``) so that downstream filter UI and tag rendering can iterate
+    over each distinct value.
     """
     for col in column_names:
         if col in df.columns:
             unique = df[col].dropna().unique()
             if len(unique) == 0:
                 return None
-            return sep.join(sorted({str(v) for v in unique}))
+            return sorted({str(v) for v in unique})
     return None
+
+
+def extract_unique_joined(
+    df: pd.DataFrame, column_names: Iterable[str], sep: str = ", "
+) -> Optional[str]:
+    """Return a sorted, deduped, joined string of all non-NaN values from the first matching column.
+
+    Thin wrapper around :func:`extract_unique_list` for callers that want a
+    display string (e.g. ``flywireType``) rather than a list to iterate over.
+    """
+    values = extract_unique_list(df, column_names)
+    return sep.join(values) if values else None

--- a/templates/sections/neuron_header.html.jinja
+++ b/templates/sections/neuron_header.html.jinja
@@ -17,17 +17,17 @@
                 </span>
                 {%- if soma_side == 'all' or soma_side == 'combined' -%}
                     {%- if complete_summary.somaNeuromere -%}
-                        <span title="Soma Neuromere" class="soma-neuromere">[{{ complete_summary.somaNeuromere }}]</span>
+                        <span title="Soma Neuromere" class="soma-neuromere">[{{ complete_summary.somaNeuromere | join(', ') }}]</span>
                     {%- endif -%}
                     {%- if complete_summary.trumanHl -%}
-                        <span title="Truman hemilineage" class="truman-hl">{{ '{' }}{{ complete_summary.trumanHl }}{{ '}' }}</span>
+                        <span title="Truman hemilineage" class="truman-hl">{{ '{' }}{{ complete_summary.trumanHl | join(', ') }}{{ '}' }}</span>
                     {%- endif -%}
                 {%- else -%}
                     {%- if summary.somaNeuromere -%}
-                        <span title="Soma Neuromere" class="soma-neuromere">[{{ summary.somaNeuromere }}]</span>
+                        <span title="Soma Neuromere" class="soma-neuromere">[{{ summary.somaNeuromere | join(', ') }}]</span>
                     {%- endif -%}
                     {%- if summary.trumanHl -%}
-                        <span title="Truman hemilineage" class="truman-hl">{{ '{' }}{{ summary.trumanHl }}{{ '}' }}</span>
+                        <span title="Truman hemilineage" class="truman-hl">{{ '{' }}{{ summary.trumanHl | join(', ') }}{{ '}' }}</span>
                     {%- endif -%}
                 {%- endif -%}
                 <a href="{{- neuprint_url -}}" target="_blank" class="external-link" title="Open {{ neuron_type }} in new neuPrint window">&#x29c9;</a>

--- a/templates/types.html.jinja
+++ b/templates/types.html.jinja
@@ -188,17 +188,18 @@
             data-rois="{% if neuron.roi_summary %}{{ neuron.roi_summary|map(attribute='name')|join(',') }}{% endif %}"
             data-parent-roi="{% if neuron.parent_rois %}{{ neuron.parent_rois|join(',') }}{% endif %}"
                 data-nt="{{ neuron.consensus_nt if neuron.consensus_nt else (neuron.celltype_predicted_nt if neuron.celltype_predicted_nt else "") }}"
-                data-class="{{ neuron.cell_class if neuron.cell_class else "" }}"
-                data-subclass="{{ neuron.cell_subclass if neuron.cell_subclass else "" }}"
-                data-superclass="{{ neuron.cell_superclass if neuron.cell_superclass else "" }}"
+                {# class/subclass/superclass/soma-neuromere/truman-hl are lists; pipe-joined for unambiguous JS splitting. #}
+                data-class="{{ neuron.cell_class | join('|') if neuron.cell_class else "" }}"
+                data-subclass="{{ neuron.cell_subclass | join('|') if neuron.cell_subclass else "" }}"
+                data-superclass="{{ neuron.cell_superclass | join('|') if neuron.cell_superclass else "" }}"
                 data-cell-count="{{ neuron.total_count if neuron.total_count else 0 }}"
                 data-left-count="{{ neuron.left_count if neuron.left_count else 0 }}"
                 data-right-count="{{ neuron.right_count if neuron.right_count else 0 }}"
                 data-middle-count="{{ neuron.middle_count if neuron.middle_count else 0 }}"
                 data-undefined-count="{{ neuron.undefined_count if neuron.undefined_count else 0 }}"
                 data-dimorphism="{{ neuron.dimorphism if neuron.dimorphism else "" }}"
-                data-soma-neuromere="{{ neuron.soma_neuromere if neuron.soma_neuromere else "" }}"
-                data-truman-hl="{{ neuron.truman_hl if neuron.truman_hl else "" }}"
+                data-soma-neuromere="{{ neuron.soma_neuromere | join('|') if neuron.soma_neuromere else "" }}"
+                data-truman-hl="{{ neuron.truman_hl | join('|') if neuron.truman_hl else "" }}"
                 data-synonyms="{{ neuron.synonyms if neuron.synonyms else "" }}"
                 data-flywire-types="{{ neuron.flywire_types if neuron.flywire_types else "" }}"
                 data-processed-synonyms="{% if neuron.processed_synonyms and neuron.processed_synonyms|length > 0 %}{{ neuron.processed_synonyms.keys() | list | join(',') }}{% endif %}"
@@ -281,17 +282,17 @@
                             <span class="view-indicator middle" title="soma side middle only">only M</span>
                             {% endif %}
 
-                            {% if neuron.cell_superclass %}
-                            <span class="class-tag superclass-tag">{{ neuron.cell_superclass }}</span>
-                            {% endif %}
+                            {% for sc in neuron.cell_superclass or [] %}
+                            <span class="class-tag superclass-tag">{{ sc }}</span>
+                            {% endfor %}
 
-                            {% if neuron.cell_class %}
-                            <span class="class-tag class-tag">{{ neuron.cell_class }}</span>
-                            {% endif %}
+                            {% for cc in neuron.cell_class or [] %}
+                            <span class="class-tag class-tag">{{ cc }}</span>
+                            {% endfor %}
 
-                            {% if neuron.cell_subclass %}
-                            <span class="class-tag subclass-tag">{{ neuron.cell_subclass }}</span>
-                            {% endif %}
+                            {% for sub in neuron.cell_subclass or [] %}
+                            <span class="class-tag subclass-tag">{{ sub }}</span>
+                            {% endfor %}
 
                             {% if neuron.consensus_nt %}
                             <span class="nt-tag">{{ neuron.consensus_nt }}</span>
@@ -303,13 +304,13 @@
                             <span class="dimorphism-tag">{{ neuron.dimorphism }}</span>
                             {% endif %}
 
-                            {% if neuron.soma_neuromere %}
-                            <span class="soma-neuromere-tag">{{ neuron.soma_neuromere }}</span>
-                            {% endif %}
+                            {% for sn in neuron.soma_neuromere or [] %}
+                            <span class="soma-neuromere-tag">{{ sn }}</span>
+                            {% endfor %}
 
-                            {% if neuron.truman_hl %}
-                            <span class="truman-hl-tag">{{ neuron.truman_hl }}</span>
-                            {% endif %}
+                            {% for hl in neuron.truman_hl or [] %}
+                            <span class="truman-hl-tag">{{ hl }}</span>
+                            {% endfor %}
 
 
                             {% if neuron.total_count and neuron.total_count > 0 %}
@@ -942,15 +943,23 @@
                 {# Check neurotransmitter filter #}
                 const matchesNt = selectedNt === "all" || cardWrapper.data("nt") === selectedNt;
 
+                {# class/subclass/superclass/soma-neuromere/truman-hl data attrs are
+                   pipe-separated lists; match if the selection appears anywhere. #}
+                const dataValuesIncludes = (attr, selection) => {
+                    const raw = cardWrapper.data(attr);
+                    if (!raw) return false;
+                    return String(raw).split("|").includes(selection);
+                };
+
                 {# Check superclass filter #}
                 const matchesSuperclass =
-                    selectedSuperclass === "all" || cardWrapper.data("superclass") === selectedSuperclass;
+                    selectedSuperclass === "all" || dataValuesIncludes("superclass", selectedSuperclass);
 
                 {# Check class filter #}
-                const matchesClass = selectedClass === "all" || cardWrapper.data("class") === selectedClass;
+                const matchesClass = selectedClass === "all" || dataValuesIncludes("class", selectedClass);
 
                 {# Check subclass filter #}
-                const matchesSubclass = selectedSubclass === "all" || cardWrapper.data("subclass") === selectedSubclass;
+                const matchesSubclass = selectedSubclass === "all" || dataValuesIncludes("subclass", selectedSubclass);
 
                 {# Check dimorphism filter #}
                 const matchesDimorphism =
@@ -958,11 +967,11 @@
 
                 {# Check soma neuromere filter #}
                 const matchesSomaNeuromere =
-                    selectedSomaNeuromere === "all" || cardWrapper.data("soma-neuromere") === selectedSomaNeuromere;
+                    selectedSomaNeuromere === "all" || dataValuesIncludes("soma-neuromere", selectedSomaNeuromere);
 
                 {# Check truman hl filter #}
                 const matchesTrumanHl =
-                    selectedTrumanHl === "all" || cardWrapper.data("truman-hl") === selectedTrumanHl;
+                    selectedTrumanHl === "all" || dataValuesIncludes("truman-hl", selectedTrumanHl);
 
                 {# Check cell count filter #}
                 const matchesCellCount = (() => {

--- a/test/test_df_utils.py
+++ b/test/test_df_utils.py
@@ -4,7 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from neuview.utils.df_utils import extract_first_non_null, extract_unique_joined
+from neuview.utils.df_utils import (
+    extract_first_non_null,
+    extract_unique_joined,
+    extract_unique_list,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -19,9 +23,7 @@ class TestExtractFirstNonNull:
                 "synonyms": [np.nan, "old-name", "old-name"],
             }
         )
-        assert (
-            extract_first_non_null(df, ("synonyms_y", "synonyms")) == "old-name"
-        )
+        assert extract_first_non_null(df, ("synonyms_y", "synonyms")) == "old-name"
 
     def test_prefers_first_listed_column_when_present(self):
         df = pd.DataFrame(
@@ -30,15 +32,11 @@ class TestExtractFirstNonNull:
                 "synonyms": ["from-x", "from-x"],
             }
         )
-        assert (
-            extract_first_non_null(df, ("synonyms_y", "synonyms")) == "from-y"
-        )
+        assert extract_first_non_null(df, ("synonyms_y", "synonyms")) == "from-y"
 
     def test_falls_through_to_second_column(self):
         df = pd.DataFrame({"synonyms": ["only-here"]})
-        assert (
-            extract_first_non_null(df, ("synonyms_y", "synonyms")) == "only-here"
-        )
+        assert extract_first_non_null(df, ("synonyms_y", "synonyms")) == "only-here"
 
     def test_returns_none_when_all_nan(self):
         df = pd.DataFrame({"synonyms": [np.nan, np.nan]})
@@ -57,9 +55,7 @@ class TestExtractUniqueJoined:
     def test_aggregates_unique_values_skipping_nan(self):
         # Reproduces the AKA-name bug: row 0's flywireType is NaN, so the
         # old first-row-only approach dropped "MTe05".
-        df = pd.DataFrame(
-            {"flywireType": [np.nan, "MTe05", "MTe06", "MTe05"]}
-        )
+        df = pd.DataFrame({"flywireType": [np.nan, "MTe05", "MTe06", "MTe05"]})
         assert (
             extract_unique_joined(df, ("flywireType_y", "flywireType"))
             == "MTe05, MTe06"
@@ -67,9 +63,7 @@ class TestExtractUniqueJoined:
 
     def test_result_is_sorted(self):
         df = pd.DataFrame({"flywireType": ["MTe06", "MTe05", "MTe07"]})
-        assert (
-            extract_unique_joined(df, ("flywireType",)) == "MTe05, MTe06, MTe07"
-        )
+        assert extract_unique_joined(df, ("flywireType",)) == "MTe05, MTe06, MTe07"
 
     def test_prefers_first_listed_column_when_present(self):
         df = pd.DataFrame(
@@ -78,9 +72,7 @@ class TestExtractUniqueJoined:
                 "flywireType": ["C", "D"],
             }
         )
-        assert (
-            extract_unique_joined(df, ("flywireType_y", "flywireType")) == "A, B"
-        )
+        assert extract_unique_joined(df, ("flywireType_y", "flywireType")) == "A, B"
 
     def test_returns_none_when_all_nan(self):
         df = pd.DataFrame({"flywireType": [np.nan, np.nan]})
@@ -88,10 +80,47 @@ class TestExtractUniqueJoined:
 
     def test_returns_none_when_no_listed_column_present(self):
         df = pd.DataFrame({"other": ["x"]})
-        assert (
-            extract_unique_joined(df, ("flywireType_y", "flywireType")) is None
-        )
+        assert extract_unique_joined(df, ("flywireType_y", "flywireType")) is None
 
     def test_custom_separator(self):
         df = pd.DataFrame({"flywireType": ["A", "B"]})
         assert extract_unique_joined(df, ("flywireType",), sep=" | ") == "A | B"
+
+
+class TestExtractUniqueList:
+    def test_aggregates_unique_sorted_values_skipping_nan(self):
+        # Reproduces the pre-fix bug for somaNeuromere: cells of the same
+        # celltype legitimately occupy different neuromeres, but the old
+        # first-row-only logic dropped all but one and was non-deterministic
+        # under join ordering.
+        df = pd.DataFrame({"somaNeuromere": [np.nan, "T2", "T1", "T2", "T3"]})
+        assert extract_unique_list(df, ("somaNeuromere_y", "somaNeuromere")) == [
+            "T1",
+            "T2",
+            "T3",
+        ]
+
+    def test_prefers_first_listed_column_when_present(self):
+        df = pd.DataFrame(
+            {
+                "cellSubclass_y": ["A", "B"],
+                "cellSubclass": ["C", "D"],
+            }
+        )
+        assert extract_unique_list(df, ("cellSubclass_y", "cellSubclass")) == ["A", "B"]
+
+    def test_falls_through_to_second_column(self):
+        df = pd.DataFrame({"trumanHl": ["0A", "0A"]})
+        assert extract_unique_list(df, ("trumanHl_y", "trumanHl")) == ["0A"]
+
+    def test_returns_none_when_all_nan(self):
+        df = pd.DataFrame({"cellClass": [np.nan, np.nan]})
+        assert extract_unique_list(df, ("cellClass",)) is None
+
+    def test_returns_none_when_no_listed_column_present(self):
+        df = pd.DataFrame({"other": [1]})
+        assert extract_unique_list(df, ("cellClass_y", "cellClass")) is None
+
+    def test_single_value_returns_single_element_list(self):
+        df = pd.DataFrame({"cellSuperclass": ["sensory", "sensory", np.nan]})
+        assert extract_unique_list(df, ("cellSuperclass",)) == ["sensory"]


### PR DESCRIPTION
These fields are not celltype-invariant. A probe of the FAFB showed celltypes with up to 7 distinct `cellClass` values across their cells. The previous extract_first_non_null logic kept whichever value landed in row 0 of the merged dataframe, which was non-deterministic under join ordering and silently discarded the other values.

- New `extract_unique_list` helper returning `Optional[List[str]]`; refactor `extract_unique_joined` as a thin wrapper around it.
- Widen `NeuronTypeCacheData.{cell_class,cell_subclass,cell_superclass, soma_neuromere,truman_hl}` to `Optional[List[str]]`.
- Filter aggregator iterates lists via a (key, target) table.
- Index card data-* attributes are pipe-joined; class/subclass/...-tag rendering loops once per value; JS filter matches via a `split('|') + includes()` helper instead of strict equality.
- Per-celltype page header joins the lists with ", " for display.
- Unit tests for extract_unique_list covering the bug case, prefix fallthrough, all-NaN, and single-value wrap.