### PR TITLE
fix path for scatterplots

### DIFF
--- a/templates/sections/scatterplots.html.jinja
+++ b/templates/sections/scatterplots.html.jinja
@@ -1,7 +1,7 @@
 {#- Scatterplots Row -#}
 <div class="row">
     {%- for region in ['ME', 'LO', 'LOP'] -%}
-    {%- set svg_path = '../../output/scatter/' ~ region ~ '.svg' -%}
+    {%- set svg_path = '../scatter/' ~ region ~ '.svg' -%}
     <div class="col-md-4 col-sm-6 col-xs-12">
       <div class="scatterplot-container">
         <object data="{{- svg_path -}}#highlight={{ neuron_data.type | urlencode }}" type="image/svg+xml" class="grid-image">

--- a/templates/sections/scatterplots_single.html.jinja
+++ b/templates/sections/scatterplots_single.html.jinja
@@ -2,11 +2,11 @@
 <div class="row">
     {%- for region in ['ME','LO','LOP'] -%}
         {%- if soma_side == 'left' -%}
-          {%- set svg_path = '../../output/scatter/' ~ region ~ '_L.svg' -%}
+          {%- set svg_path = '../scatter/' ~ region ~ '_L.svg' -%}
         {%- elif soma_side == 'right' -%}
-          {%- set svg_path = '../../output/scatter/' ~ region ~ '_R.svg' -%}
+          {%- set svg_path = '../scatter/' ~ region ~ '_R.svg' -%}
         {%- else -%}
-          {%- set svg_path = '../../output/scatter/' ~ region ~ '.svg' -%}
+          {%- set svg_path = '../scatter/' ~ region ~ '.svg' -%}
         {%- endif -%}
     <div class="col-md-4 col-sm-6 col-xs-12">
       <div class="scatterplot-container">


### PR DESCRIPTION
On the webserver, the freshly generated websites only showed the alt text for the scatterplots. The reason: the path went up 2 levels and then went to `output/scatter`. That path exists in the local test in neuview, but not on the webserver. This fixes it. I am also trying to update the paths for the the published MCNS and FAFB datasets rn.