### PR TITLE
render side with most synapses

### DIFF
--- a/src/neuview/services/column_analysis_service.py
+++ b/src/neuview/services/column_analysis_service.py
@@ -139,6 +139,76 @@ class ColumnAnalysisService:
             # Generate summary statistics
             summary_stats = self._generate_column_summary_statistics(column_summary)
 
+            # Combined page: delegate eyemap selection to the L-soma and
+            # R-soma analyses. Each side's analysis runs its own contralateral
+            # check and emits grids keyed by the *grid* hemisphere (post-swap).
+            # We merge those dicts as-is so the slot in the template matches
+            # the hemisphere the file actually depicts — i.e. for CT1 the L
+            # slot displays the L-hemisphere SVG (sourced from the R-soma
+            # analysis) and the R slot displays the R-hemisphere SVG (from
+            # the L-soma analysis). No separate combined-mode files are
+            # produced.
+            soma_side_lower = (
+                soma_side.lower() if isinstance(soma_side, str) else ""
+            )
+            if soma_side_lower == "combined":
+                if "somaSide" in neurons_df.columns:
+                    l_neurons = neurons_df[neurons_df["somaSide"] == "L"]
+                    r_neurons = neurons_df[neurons_df["somaSide"] == "R"]
+                else:
+                    l_neurons = neurons_df.iloc[0:0]
+                    r_neurons = neurons_df.iloc[0:0]
+
+                merged_grids = {}
+                fallback_all_count = 0
+                fallback_region_counts = {}
+                for side_neurons, side_name in (
+                    (l_neurons, "left"),
+                    (r_neurons, "right"),
+                ):
+                    if side_neurons.empty:
+                        continue
+                    side_result = self.analyze_column_roi_data(
+                        roi_counts_df,
+                        side_neurons,
+                        side_name,
+                        neuron_type,
+                        connector,
+                        file_type,
+                        save_to_files,
+                        hex_size,
+                        spacing_factor,
+                    )
+                    if not side_result:
+                        continue
+                    # Use the keys from the per-side result verbatim: they
+                    # already reflect the grid hemisphere, which is what we
+                    # want the combined-page slot to match.
+                    merged_grids.update(
+                        side_result.get("comprehensive_region_grids", {})
+                    )
+                    if not fallback_all_count:
+                        fallback_all_count = side_result.get(
+                            "all_possible_columns_count", 0
+                        )
+                        fallback_region_counts = side_result.get(
+                            "region_columns_counts", {}
+                        )
+
+                combined_result = {
+                    "columns": column_summary,
+                    "summary": summary_stats,
+                    "comprehensive_region_grids": merged_grids,
+                    "all_possible_columns_count": fallback_all_count,
+                    "region_columns_counts": fallback_region_counts,
+                }
+                self._column_analysis_cache[cache_key] = combined_result
+                logger.info(
+                    f"analyze_column_roi_data: combined merged from L/R for "
+                    f"{cache_key} in {time.time() - start_time:.3f}s"
+                )
+                return combined_result
+
             # Get comprehensive column data for hexagon grids
             all_possible_columns, region_columns_map = (
                 self.page_generator.database_query_service.get_all_possible_columns_from_dataset(
@@ -185,6 +255,54 @@ class ColumnAnalysisService:
                     SomaSide(soma_side) if isinstance(soma_side, str) else soma_side
                 )
 
+                # Detect contralateral-dominant types (e.g. CT1, DNc02): the
+                # cells' soma is on one side but their synapses live in the
+                # opposite hemisphere's columns. Compute synapse and cell
+                # totals per column-side and, when the contra hemisphere wins
+                # on BOTH counts, redirect the grid generation to render the
+                # contralateral side. The page_soma_side preserves the
+                # original soma side; downstream callers compare it with
+                # soma_side to know whether the grid is contralateral.
+                page_soma_side_enum = soma_side_enum
+                soma_side_lower = (
+                    soma_side.lower() if isinstance(soma_side, str) else ""
+                )
+                if soma_side_lower in ("left", "right"):
+                    ipsi = "L" if soma_side_lower == "left" else "R"
+                    contra = "R" if ipsi == "L" else "L"
+                    ipsi_syn = sum(
+                        c.get("total_synapses", 0)
+                        for c in column_summary
+                        if c.get("side") == ipsi
+                    )
+                    contra_syn = sum(
+                        c.get("total_synapses", 0)
+                        for c in column_summary
+                        if c.get("side") == contra
+                    )
+                    ipsi_cells = sum(
+                        c.get("neuron_count", 0)
+                        for c in column_summary
+                        if c.get("side") == ipsi
+                    )
+                    contra_cells = sum(
+                        c.get("neuron_count", 0)
+                        for c in column_summary
+                        if c.get("side") == contra
+                    )
+                    if contra_syn > ipsi_syn and contra_cells > ipsi_cells:
+                        soma_side_enum = (
+                            SomaSide.RIGHT
+                            if soma_side_lower == "left"
+                            else SomaSide.LEFT
+                        )
+                        logger.info(
+                            f"{neuron_type}/{soma_side}: contralateral dominance "
+                            f"(syn ipsi={ipsi_syn} vs contra={contra_syn}, "
+                            f"cells ipsi={ipsi_cells} vs contra={contra_cells}); "
+                            f"rendering {contra}-hemisphere eyemaps"
+                        )
+
                 # Create grid generation request
                 grid_request = create_grid_generation_request(
                     column_data=column_data,
@@ -196,6 +314,7 @@ class ColumnAnalysisService:
                     output_format=file_type,
                     save_to_files=save_to_files,
                     min_max_data=min_max_data,
+                    page_soma_side=page_soma_side_enum,
                 )
 
                 # Generate grids using new interface

--- a/src/neuview/visualization/data_transfer_objects.py
+++ b/src/neuview/visualization/data_transfer_objects.py
@@ -28,6 +28,12 @@ class GridGenerationRequest:
     output_format: str = "svg"
     save_to_files: bool = True
     min_max_data: Optional[Dict] = None
+    # The page's *original* soma side. When ``soma_side`` differs from this
+    # (i.e. the caller redirected to the contralateral hemisphere because the
+    # neurons' synapses+cells favour the opposite side), downstream code
+    # marks the SVG with a hemisphere badge that differs from the cell-type
+    # badge and tags the output file with a ``_con`` suffix.
+    page_soma_side: Optional[SomaSide] = None
 
     @property
     def regions(self) -> List[str]:
@@ -82,6 +88,8 @@ class SingleRegionGridRequest:
     output_format: str = "svg"
     other_regions_coords: Optional[Set] = None
     min_max_data: Optional[Dict] = None
+    # Propagated from the outer GridGenerationRequest — see that class.
+    page_soma_side: Optional[SomaSide] = None
 
     def __post_init__(self):
         """Validate the request parameters."""
@@ -104,15 +112,19 @@ class RenderingRequest:
     min_val: float
     max_val: float
     thresholds: Dict
-    plot_desc: str
-    neuron_desc: str
-    region_desc: str
+    plot_desc: str         # e.g. "Synapses (All Columns)"
+    roi: str               # ROI label, e.g. "ME" / "LO" / "LOP"
+    neuron_type: str       # Cell type label, e.g. "CT1" / "Tm3"
     metric_type: str
     soma_side: SomaSide
     output_format: str = "svg"
     save_to_file: bool = False
     filename: Optional[str] = None
     min_max_data: Optional[Dict] = None
+    # The page's *original* soma side (before any contralateral swap). Used
+    # to decide whether the rendered hemisphere is opposite the soma side
+    # (= contralateral); compare with ``soma_side`` at the point of use.
+    page_soma_side: Optional[SomaSide] = None
 
     def __post_init__(self):
         """Validate the rendering request."""
@@ -204,26 +216,26 @@ def create_rendering_request(
     max_val: float,
     thresholds: Dict,
     plot_desc: str,
-    neuron_desc: str,
-    region_desc: str,
+    roi: str,
+    neuron_type: str,
     metric_type: str,
     soma_side: SomaSide,
     **kwargs,
 ) -> RenderingRequest:
     """
-    Factory function to create a RenderingRequest with modern types.
+    Factory function to create a RenderingRequest.
 
     Args:
         hexagons: List of hexagon data dictionaries
         min_val: Minimum value for scaling
         max_val: Maximum value for scaling
         thresholds: Threshold values dictionary
-        plot_desc: Type description, e.g. Synapses or Cell count, as shown in the figure
-        neuron_desc: Neuron name description as shown in the figure
-        region_desc: Region name description as shown in the figure
+        plot_desc: Metric label shown in the figure (e.g. "Synapses (All Columns)")
+        roi: ROI label, e.g. "ME" / "LO" / "LOP"
+        neuron_type: Cell type label, e.g. "CT1" / "Tm3"
         metric_type: Type of metric being displayed
         soma_side: Side of soma (SomaSide enum)
-        **kwargs: Additional optional parameters (including min_max_data)
+        **kwargs: Additional optional parameters (including ``page_soma_side``)
 
     Returns:
         RenderingRequest object
@@ -238,8 +250,8 @@ def create_rendering_request(
         max_val=max_val,
         thresholds=thresholds,
         plot_desc=plot_desc,
-        neuron_desc=neuron_desc,
-        region_desc=region_desc,
+        roi=roi,
+        neuron_type=neuron_type,
         metric_type=metric_type,
         soma_side=soma_side,
         **kwargs,

--- a/src/neuview/visualization/eyemap_generator.py
+++ b/src/neuview/visualization/eyemap_generator.py
@@ -382,46 +382,18 @@ class EyemapGenerator:
                     request.thresholds,
                 )
 
-                # Set up visualization metadata
+                # Plain text labels — the side letters travel through the
+                # rendering pipeline as separate fields (rendered as colored
+                # badges next to the labels in the SVG template).
                 if request.metric_type == METRIC_SYNAPSE_DENSITY:
                     plot_desc = "Synapses (All Columns)"
-                    # Handle both string and SomaSide enum inputs
-                    if hasattr(request.soma_side, "value"):
-                        soma_display = (
-                            request.soma_side.value.upper()[:1]
-                            if request.soma_side
-                            else ""
-                        )
-                    else:
-                        soma_display = (
-                            str(request.soma_side).upper()[:1]
-                            if request.soma_side
-                            else ""
-                        )
-                    neuron_desc = f"{request.region_name} ({soma_display})"
-                    region_desc = f"{request.neuron_type} ({soma_display})"
                 else:  # cell_count
                     plot_desc = "Cell Count (All Columns)"
-                    # Handle both string and SomaSide enum inputs
-                    if hasattr(request.soma_side, "value"):
-                        soma_display = (
-                            request.soma_side.value.upper()[:1]
-                            if request.soma_side
-                            else ""
-                        )
-                    else:
-                        soma_display = (
-                            str(request.soma_side).upper()[:1]
-                            if request.soma_side
-                            else ""
-                        )
-                    neuron_desc = f"{request.region_name} ({soma_display})"
-                    region_desc = f"{request.neuron_type} ({soma_display})"
 
                 grid_metadata = {
                     "plot_desc": plot_desc,
-                    "neuron_desc": neuron_desc,
-                    "region_desc": region_desc,
+                    "roi": request.region_name,
+                    "neuron_type": request.neuron_type,
                 }
 
                 # Create processing configuration
@@ -654,11 +626,12 @@ class EyemapGenerator:
                     max_val=value_range["max_value"],
                     thresholds=request.thresholds or {},
                     plot_desc=grid_metadata["plot_desc"],
-                    neuron_desc=grid_metadata["neuron_desc"],
-                    region_desc=grid_metadata["region_desc"],
+                    roi=grid_metadata["roi"],
+                    neuron_type=grid_metadata["neuron_type"],
                     metric_type=request.metric_type,
                     soma_side=request.soma_side or SomaSide.RIGHT,
                     min_max_data=request.min_max_data,
+                    page_soma_side=getattr(request, "page_soma_side", None),
                 )
 
                 # Use rendering manager to generate visualization
@@ -697,13 +670,16 @@ class EyemapGenerator:
                 # Update rendering manager configuration with rendering parameters
                 updated_config = self.rendering_manager.config.copy(
                     plot_desc=rendering_request.plot_desc,
-                    neuron_desc=rendering_request.neuron_desc,
-                    region_desc=rendering_request.region_desc,
+                    region_name=rendering_request.roi,
+                    neuron_type=rendering_request.neuron_type,
                     metric_type=rendering_request.metric_type,
                     soma_side=soma_side_enum,
                     thresholds=rendering_request.thresholds,
                     save_to_files=rendering_request.save_to_file,
                     min_max_data=rendering_request.min_max_data,
+                    page_soma_side=getattr(
+                        rendering_request, "page_soma_side", None
+                    ),
                 )
 
                 # Create temporary manager with updated config

--- a/src/neuview/visualization/file_output_manager.py
+++ b/src/neuview/visualization/file_output_manager.py
@@ -142,12 +142,20 @@ class FileOutputManager:
 
         renderer = rendering_manager._get_renderer(format_enum)
 
-        # Generate file names
+        # Generate file names. Contralateral renders go to a distinct
+        # filename so combined-page eyemaps and side-page eyemaps (with the
+        # mismatched-hemisphere badge) don't collide on disk. The render is
+        # contralateral when the page's original soma side differs from the
+        # hemisphere being drawn.
+        page_soma = getattr(request, "page_soma_side", None)
+        is_contralateral = (
+            page_soma is not None and page_soma != request.soma_side
+        )
         synapse_filename = self._generate_filename(
-            region, request.neuron_type, side, "synapse_density"
+            region, request.neuron_type, side, "synapse_density", is_contralateral
         )
         cell_filename = self._generate_filename(
-            region, request.neuron_type, side, "cell_count"
+            region, request.neuron_type, side, "cell_count", is_contralateral
         )
 
         # Check if files already exist and return existing paths if so
@@ -202,7 +210,12 @@ class FileOutputManager:
             raise ValueError(f"Unsupported output format: {output_format}")
 
     def _generate_filename(
-        self, region: str, neuron_type: str, side: str, metric_type: str
+        self,
+        region: str,
+        neuron_type: str,
+        side: str,
+        metric_type: str,
+        is_contralateral: bool = False,
     ) -> str:
         """
         Generate a standardized filename for eyemap files.
@@ -212,11 +225,16 @@ class FileOutputManager:
             neuron_type: Neuron type identifier
             side: Side identifier
             metric_type: Type of metric ('synapse_density' or 'cell_count')
+            is_contralateral: When True, the rendered hemisphere is opposite
+                the soma side and the SVG carries a "con" marker. The
+                filename gets a "_con" suffix so contralateral and
+                ipsilateral renders don't share a path on disk.
 
         Returns:
             Generated filename (without extension)
         """
-        return f"{region}_{neuron_type}_{side}_{metric_type}"
+        suffix = "_con" if is_contralateral else ""
+        return f"{region}_{neuron_type}_{side}_{metric_type}{suffix}"
 
     def get_output_path(
         self, filename: str, use_eyemaps_dir: bool = True

--- a/src/neuview/visualization/region_grid_processor.py
+++ b/src/neuview/visualization/region_grid_processor.py
@@ -167,11 +167,11 @@ class RegionGridProcessor:
         """
         # Create requests for single region grid generation
         synapse_request = self._create_metric_request(
-            request, region, data_map, region_config, "synapse_density"
+            request, region, data_map, region_config, "synapse_density", side
         )
 
         cell_request = self._create_metric_request(
-            request, region, data_map, region_config, "cell_count"
+            request, region, data_map, region_config, "cell_count", side
         )
 
         # Generate the grids
@@ -187,6 +187,7 @@ class RegionGridProcessor:
         data_map: Dict,
         region_config: Dict,
         metric_type: str,
+        side: str,
     ) -> SingleRegionGridRequest:
         """
         Create a SingleRegionGridRequest for a specific metric type.
@@ -197,6 +198,10 @@ class RegionGridProcessor:
             data_map: Data map for the current side
             region_config: Region-specific configuration
             metric_type: Either 'synapse_density' or 'cell_count'
+            side: "L" or "R" — the hemisphere being rendered by this single
+                grid. Differs from request.soma_side for combined pages where
+                the outer request claims COMBINED but each individual grid is
+                still L or R.
 
         Returns:
             SingleRegionGridRequest for the specified metric
@@ -207,18 +212,33 @@ class RegionGridProcessor:
         else:  # cell_count
             thresholds = request.thresholds_all["neuron_count"]
 
+        # Use the per-grid side as the soma_side on the inner request: it
+        # drives labels (e.g. "ME (L)") and the layout calculator's left/right
+        # control placement. For L/R pages this matches request.soma_side; for
+        # combined pages the outer is COMBINED but each grid is still L or R.
+        from .data_processing.data_structures import SomaSide
+
+        side_letter = (side or "").upper()
+        if side_letter == "L":
+            grid_soma_side = SomaSide.LEFT
+        elif side_letter == "R":
+            grid_soma_side = SomaSide.RIGHT
+        else:
+            grid_soma_side = request.soma_side
+
         return create_single_region_request(
             region_config["side_filtered_columns"],
             region_config["region_column_coords"],
             data_map,
             metric_type,
             region,
-            soma_side=request.soma_side,
+            soma_side=grid_soma_side,
             thresholds=thresholds,
             neuron_type=request.neuron_type,
             output_format=request.output_format,
             other_regions_coords=region_config["other_regions_coords"],
             min_max_data=request.min_max_data,
+            page_soma_side=getattr(request, "page_soma_side", None),
         )
 
     def determine_mirror_side(self, soma_side: str, current_side: str) -> str:

--- a/src/neuview/visualization/rendering/layout_calculator.py
+++ b/src/neuview/visualization/rendering/layout_calculator.py
@@ -96,6 +96,22 @@ class LayoutCalculator:
         svg_width = max(base_width, control_space["min_width"])
         svg_height = max(base_height, control_space["min_height"])
 
+        # Enforce a per-region canvas floor so the L and R eyemaps for the
+        # same region render at identical SVG dimensions even though the L/R
+        # hex coordinate sets aren't strictly symmetric (R extends ~10px
+        # wider and ~6px taller for optic-lobe regions). The floor is the
+        # observed max plus a small buffer; the underlying hex content
+        # positions are unchanged, only the canvas around them grows.
+        region_canvas_floor = {
+            "ME": (380, 410),
+            "LO": (380, 410),
+            "LOP": (380, 410),
+        }
+        if region in region_canvas_floor:
+            floor_w, floor_h = region_canvas_floor[region]
+            svg_width = max(svg_width, floor_w)
+            svg_height = max(svg_height, floor_h)
+
         # Calculate layer control positioning
         layer_control_x, layer_control_y = self._calculate_layer_control_position(
             svg_width, svg_height, soma_side, control_dimensions

--- a/src/neuview/visualization/rendering/rendering_config.py
+++ b/src/neuview/visualization/rendering/rendering_config.py
@@ -53,13 +53,15 @@ class RenderingConfig:
     png_scale: float = 1.0
 
     # Content configuration
-    plot_desc: str = ""
-    neuron_desc: str = ""
-    region_desc: str = ""
+    plot_desc: str = ""    # metric label, e.g. "Synapses (All Columns)"
     metric_type: str = ""
     soma_side: Optional[SomaSide] = None
-    neuron_type: Optional[str] = None
-    region_name: Optional[str] = None
+    neuron_type: Optional[str] = None   # cell type label, e.g. "CT1"
+    region_name: Optional[str] = None   # ROI label, e.g. "ME"
+    # The page's original soma side. When it differs from ``soma_side`` the
+    # rendered hemisphere is contralateral to the soma side; the SVG template
+    # uses the difference to colour the two header badges differently.
+    page_soma_side: Optional[SomaSide] = None
 
     # Data configuration
     min_max_data: Optional[Dict[str, Any]] = None

--- a/src/neuview/visualization/rendering/svg_renderer.py
+++ b/src/neuview/visualization/rendering/svg_renderer.py
@@ -234,13 +234,29 @@ class SVGRenderer(BaseRenderer):
         # Get data hexagons for legend
         data_hexagons = [h for h in hexagons if h.get("status") == "has_data"]
 
+        # Helper for the single-letter side: derive "L"/"R" from a SomaSide
+        # enum or string, returning "" for None / COMBINED / MIDDLE.
+        def _side_letter(side):
+            if side is None:
+                return ""
+            value = side.value if hasattr(side, "value") else str(side)
+            letter = value.upper()[:1] if value else ""
+            return letter if letter in ("L", "R") else ""
+
+        render_side = _side_letter(self.config.soma_side)
+        cell_type_side = (
+            _side_letter(self.config.page_soma_side)
+            if getattr(self.config, "page_soma_side", None) is not None
+            else render_side
+        )
+
         # Prepare template variables
         template_vars = {
             "width": layout_config.width,
             "height": layout_config.height,
             "plot_desc": self.config.plot_desc,
-            "neuron_desc": self.config.neuron_desc,
-            "region_desc": self.config.region_desc,
+            "neuron_type": self.config.neuron_type or "",
+            "roi": self.config.region_name or "",
             "hexagons": hexagons,
             "hex_points": layout_config.hex_points.split(),
             "min_x": layout_config.min_x,
@@ -260,6 +276,8 @@ class SVGRenderer(BaseRenderer):
             "enumerate": enumerate,
             "soma_side": self.config.soma_side,
             "min_max_data": self.config.min_max_data or {},
+            "render_side": render_side,
+            "cell_type_side": cell_type_side,
         }
 
         # Add color information if available

--- a/templates/eyemap.svg.jinja
+++ b/templates/eyemap.svg.jinja
@@ -275,10 +275,16 @@ function updateLayer(layer, regionId) {
 {#-- Background --#}
 <rect width="{{ width + 40 }}" height="{{ height }}" fill="#f8f9fa" stroke="none" />
 
-{#-- Plot Name, Region Name, Neuron Name, and Layer Scrollbar --#}
+{#-- Plot title, cell type, ROI. Each label uses <text> with a trailing
+     <tspan> for the side letter so the browser handles letter spacing
+     instead of us approximating text width from character count. The
+     side letter is rendered bold + colored (red R / green L matching the
+     soma-side colours used elsewhere on the page); group opacity matches
+     the visual weight of the surrounding gray text labels. --#}
+{%- macro side_color(side) -%}{%- if side == "R" -%}#dc3545{%- elif side == "L" -%}#28a745{%- endif -%}{%- endmacro -%}
 <text x="5" y="15" text-anchor="start" font-family="Arial, sans-serif" font-size="12" fill="#CCCCCC">{{ plot_desc }}</text>
-<text x="5" y="28" text-anchor="start" font-family="Arial, sans-serif" font-size="10" fill="#CCCCCC">{{ region_desc }}</text>
-<text x="5" y="41" text-anchor="start" font-family="Arial, sans-serif" font-size="10" fill="#CCCCCC">{{ neuron_desc }}</text>
+<text x="5" y="28" text-anchor="start" font-family="Arial, sans-serif" font-size="10" fill="#CCCCCC">{{ neuron_type }}{%- if cell_type_side in ("L", "R") -%}<tspan dx="6" font-weight="bold" fill="{{ side_color(cell_type_side) }}" fill-opacity="0.4">({{ cell_type_side }})</tspan>{%- endif -%}</text>
+<text x="5" y="41" text-anchor="start" font-family="Arial, sans-serif" font-size="10" fill="#CCCCCC">{{ roi }}{%- if render_side in ("L", "R") -%}<tspan dx="6" font-weight="bold" fill="{{ side_color(render_side) }}" fill-opacity="0.4">({{ render_side }})</tspan>{%- endif -%}</text>
 
 {#-- Hexagon Path Definition --#}
 {%- set hex_path = "M" + hex_points|join(" L") + " Z" -%}


### PR DESCRIPTION
For neuron types whose contra lateral innervation is larger than the ipsi lateral, it now looks like this:

<img width="324" height="268" alt="image" src="https://github.com/user-attachments/assets/057404bc-0784-4f05-abb0-3ca565f32903" />

instead of 

<img width="368" height="329" alt="image" src="https://github.com/user-attachments/assets/18184844-3a42-4cdb-a0b4-ec11c45d4a19" />


Other neurons will also highlight the side for both, the celltype and ROI, in color.

The ROIs will be show in the correct location in the combined page. This also means, the Left cell will show on the "right side", the right cell on the "left side":

<img width="1255" height="625" alt="image" src="https://github.com/user-attachments/assets/54d9199f-a05d-4de4-a8fd-acc77042bee8" />

Also, the eyemaps for left and right side now have the same size.

This partially addresses #52